### PR TITLE
restore_last_snapshot without the need of mounting

### DIFF
--- a/portfolio/hoi/index.html
+++ b/portfolio/hoi/index.html
@@ -153,7 +153,7 @@
                 wide:true,
                 border:0.3,
                 buttons: [
-		     {run: true, script: `wasm_configure('DRIVE_SPEED', '8');`},
+		     {run: true, script: `wasm_configure('DRIVE_SPEED', '8');global_apptitle='hoi.zip';`},
 		     {position:'top:0vh;left:0vw',title:'[s]ave',key:'s',script:`action('take_snapshot');`},
 		     {position:'top:0vh;right:0vw',title:'[l]oad',key:'l',script:`action('restore_last_snapshot');`}
 		],


### PR DESCRIPTION
we had to tell vAmigaWeb which savepoint to restore ... it did not know about it unless you set the apptitle by mounting the disk... to fix the bug the information had to be given to vAmigaWeb e.g. in the run script after DRIVE_SPEED=8 ... like this global_apptitle='hoi.zip'