### PR TITLE
bugfix CORS on hoi.zip

### DIFF
--- a/portfolio/hoi/index.html
+++ b/portfolio/hoi/index.html
@@ -157,7 +157,7 @@
         ],
                 port2:true,
                 display:'standard',
-                url:'https://www.proofofconcept.nl/static/hoi/hoi.zip'
+                url:'https://proofofconcept.nl/static/hoi/hoi.zip'
             }; 
             vAmigaWeb_player.load(this,encodeURIComponent(JSON.stringify(config)));
             return false;"      


### PR DESCRIPTION
Hi @rhinoid your cname change in december broke the cross origin resource sharing (CORS) of the hoi.zip ... I corrected it 🤓